### PR TITLE
Changes resulting from connection rewrite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ class SomeClient
 
   # This will be invoked by ProcessHost in order to enable cooperative
   # multitasking.
-  def change_connection_policy(policy)
-    connection.policy = policy
+  def change_connection_scheduler(scheduler)
+    connection.scheduler = scheduler
   end
 
   def connection
-    @connection ||= Connection::Client.build "127.0.0.1", 2113
+    @connection ||= Connection.client "127.0.0.1", 2113
   end
 end
 ```
@@ -44,17 +44,15 @@ class SomeServer
 
   # This will be invoked by ProcessHost in order to enable cooperative
   # multitasking.
-  def change_connection_policy(policy)
-    server_connection.policy = policy
+  def change_connection_scheduler(scheduler)
+    server_connection.scheduler = scheduler
   end
 
   def server_connection
-    @server_connection ||= Connection::Server.build "127.0.0.1", 2113
+    @server_connection ||= Connection.server 2113
   end
 end
 ```
-
-See `lib/process-host/controls/example-*` for usage examples.
 
 ## License
 

--- a/lib/process_host.rb
+++ b/lib/process_host.rb
@@ -2,5 +2,6 @@ require 'connection'
 require 'telemetry/logger'
 
 require 'process_host/cooperation'
+require 'process_host/cooperation/reactor/dispatcher'
 require 'process_host/cooperation/reactor'
 require 'process_host/process_host'

--- a/lib/process_host.rb
+++ b/lib/process_host.rb
@@ -1,5 +1,6 @@
-require "connection"
-require "telemetry/logger"
+require 'connection'
+require 'telemetry/logger'
 
-require "process_host/cooperation"
-require "process_host/process_host"
+require 'process_host/cooperation'
+require 'process_host/cooperation/reactor'
+require 'process_host/process_host'

--- a/lib/process_host/controls/example_client.rb
+++ b/lib/process_host/controls/example_client.rb
@@ -23,12 +23,12 @@ module ProcessHost
           request["Host"] = "localhost"
           logger.trace "Client is writing request headers"
           logger.data "Request headers:\n#{request}"
-          connection.write request
+          connection.write request.to_s
           logger.debug "Client has written request headers"
 
           builder = HTTP::Protocol::Response::Builder.build
           logger.trace "Client is reading response headers"
-          builder << connection.gets until builder.finished_headers?
+          builder << connection.readline("\r\n") until builder.finished_headers?
           logger.debug "Client has read response headers"
 
           response = builder.message
@@ -47,12 +47,12 @@ module ProcessHost
       end
 
       def connection
-        @connection ||= Connection::Client.build "127.0.0.1", 90210
+        @connection ||= Connection.client '127.0.0.1', 90210
       end
 
       module ProcessHostIntegration
-        def change_connection_policy(policy)
-          connection.policy = policy
+        def change_connection_scheduler(scheduler)
+          connection.scheduler = scheduler
         end
       end
     end

--- a/lib/process_host/cooperation.rb
+++ b/lib/process_host/cooperation.rb
@@ -16,8 +16,7 @@ module ProcessHost
       instance
     end
 
-    def register(process, name=nil)
-      name ||= 'unknown'
+    def register(process, name)
       ProcessHost.integrate process
       reactor.register process, name
     end

--- a/lib/process_host/cooperation.rb
+++ b/lib/process_host/cooperation.rb
@@ -1,33 +1,30 @@
 module ProcessHost
   class Cooperation
-    attr_writer :exception_notifier
+    attr_accessor :exception_notifier
     attr_reader :reactor
 
-    dependency :logger
+    dependency :logger, Telemetry::Logger
 
     def initialize(reactor)
       @reactor = reactor
     end
 
     def self.build
-      reactor = Connection::Reactor.build
+      reactor = Reactor.build
       instance = new reactor
       Telemetry::Logger.configure instance
       instance
     end
 
-    def exception_notifier
-      @exception_notifier or ->*{}
-    end
-
-    def register(process, name = nil)
+    def register(process, name=nil)
+      name ||= 'unknown'
       ProcessHost.integrate process
       reactor.register process, name
     end
 
     def start
-      reactor.run do |process, error|
-        exception_notifier.(process, error)
+      reactor.start do |process, error|
+        exception_notifier.(process, error) if exception_notifier
       end
     end
   end

--- a/lib/process_host/cooperation/reactor.rb
+++ b/lib/process_host/cooperation/reactor.rb
@@ -1,0 +1,110 @@
+module ProcessHost
+  class Cooperation
+    class Reactor
+      attr_reader :fibers
+
+      class Dispatcher
+        attr_reader :reads
+        attr_reader :writes
+
+        dependency :logger, Telemetry::Logger
+
+        def initialize
+          @reads = []
+          @writes = []
+        end
+
+        def self.build
+          instance = new
+          Telemetry::Logger.configure instance
+          instance
+        end
+
+        def self.configure(receiver)
+          instance = build
+          receiver.dispatcher = instance
+        end
+
+        def next(&block)
+          ready_reads, ready_writes, * = IO.select reads.map(&:io), writes.map(&:io), [], 1
+
+          Array(ready_reads).each do |io|
+            deferral = pending_read io
+            deferral.callback.()
+          end
+
+          Array(ready_writes).each do |io|
+            deferral = pending_write io
+            deferral.callback.()
+          end
+
+          # Cycle reads and writes so that all tasks get a slice
+          reads.push reads.shift if reads.any?
+          writes.push writes.shift if writes.any?
+        end
+
+        def pending_read(io)
+          reads.detect do |deferral|
+            deferral.io == io
+          end
+        end
+
+        def pending_write(io)
+          writes.detect do |deferral|
+            deferral.io == io
+          end
+        end
+
+        def wait_readable(io, &callback)
+          readable, * = IO.select [io], [], [], 0
+          logger.debug "Deferring read (Fileno: #{io.fileno})"
+          deferral = Deferral.new io, callback
+          reads << deferral unless pending_read io
+        end
+
+        def wait_writable(io, &callback)
+          logger.debug "Deferring write (Fileno: #{io.fileno})"
+          deferral = Deferral.new io, callback
+          writes << deferral unless pending_write io
+        end
+      end
+      dependency :dispatcher, Dispatcher
+      dependency :logger, Telemetry::Logger
+
+      Deferral = Struct.new :io, :callback
+
+      def initialize
+        @fibers = {}
+      end
+
+      def self.build
+        instance = new
+        Dispatcher.configure instance
+        Telemetry::Logger.configure instance
+        instance
+      end
+
+      def register(process, name)
+        process.change_connection_scheduler scheduler
+
+        fibers[name] = Fiber.new do
+          process.start
+        end
+      end
+
+      def scheduler
+        @scheduler ||= Connection::Scheduler::Cooperative.build dispatcher
+      end
+
+      def start
+        fibers.each_value &:resume
+
+        while fibers.any?
+          logger.debug "Started Iteration (Fibers: #{fibers.keys * ', '})"
+          dispatcher.next
+          fibers.select! { |_, fiber| fiber.alive? }
+        end
+      end
+    end
+  end
+end

--- a/lib/process_host/cooperation/reactor.rb
+++ b/lib/process_host/cooperation/reactor.rb
@@ -3,75 +3,8 @@ module ProcessHost
     class Reactor
       attr_reader :fibers
 
-      class Dispatcher
-        attr_reader :reads
-        attr_reader :writes
-
-        dependency :logger, Telemetry::Logger
-
-        def initialize
-          @reads = []
-          @writes = []
-        end
-
-        def self.build
-          instance = new
-          Telemetry::Logger.configure instance
-          instance
-        end
-
-        def self.configure(receiver)
-          instance = build
-          receiver.dispatcher = instance
-        end
-
-        def next(&block)
-          ready_reads, ready_writes, * = IO.select reads.map(&:io), writes.map(&:io), [], 1
-
-          Array(ready_reads).each do |io|
-            deferral = pending_read io
-            deferral.callback.()
-          end
-
-          Array(ready_writes).each do |io|
-            deferral = pending_write io
-            deferral.callback.()
-          end
-
-          # Cycle reads and writes so that all tasks get a slice
-          reads.push reads.shift if reads.any?
-          writes.push writes.shift if writes.any?
-        end
-
-        def pending_read(io)
-          reads.detect do |deferral|
-            deferral.io == io
-          end
-        end
-
-        def pending_write(io)
-          writes.detect do |deferral|
-            deferral.io == io
-          end
-        end
-
-        def wait_readable(io, &callback)
-          readable, * = IO.select [io], [], [], 0
-          logger.debug "Deferring read (Fileno: #{io.fileno})"
-          deferral = Deferral.new io, callback
-          reads << deferral unless pending_read io
-        end
-
-        def wait_writable(io, &callback)
-          logger.debug "Deferring write (Fileno: #{io.fileno})"
-          deferral = Deferral.new io, callback
-          writes << deferral unless pending_write io
-        end
-      end
       dependency :dispatcher, Dispatcher
       dependency :logger, Telemetry::Logger
-
-      Deferral = Struct.new :io, :callback
 
       def initialize
         @fibers = {}
@@ -105,6 +38,8 @@ module ProcessHost
           fibers.select! { |_, fiber| fiber.alive? }
         end
       end
+
+      Deferral = Struct.new :io, :callback
     end
   end
 end

--- a/lib/process_host/cooperation/reactor/dispatcher.rb
+++ b/lib/process_host/cooperation/reactor/dispatcher.rb
@@ -34,9 +34,11 @@ module ProcessHost
 
           ready_reads.each do |deferral|
             deferral.callback.()
+            reads.delete deferral
           end
           ready_writes.each do |deferral|
             deferral.callback.()
+            writes.delete deferral
           end
 
           cycle_deferrals
@@ -70,13 +72,13 @@ module ProcessHost
           readable, * = IO.select [io], [], [], 0
           logger.debug "Deferring read (Fileno: #{io.fileno})"
           deferral = Deferral.new io, callback
-          reads << deferral unless pending_read io
+          reads << deferral
         end
 
         def wait_writable(io, &callback)
           logger.debug "Deferring write (Fileno: #{io.fileno})"
           deferral = Deferral.new io, callback
-          writes << deferral unless pending_write io
+          writes << deferral
         end
       end
     end

--- a/lib/process_host/cooperation/reactor/dispatcher.rb
+++ b/lib/process_host/cooperation/reactor/dispatcher.rb
@@ -32,8 +32,12 @@ module ProcessHost
         def next(&block)
           ready_reads, ready_writes = select
 
-          ready_reads.each { |deferral| deferral.callback.() }
-          ready_writes.each { |deferral| deferral.callback.() }
+          ready_reads.each do |deferral|
+            deferral.callback.()
+          end
+          ready_writes.each do |deferral|
+            deferral.callback.()
+          end
 
           cycle_deferrals
         end

--- a/lib/process_host/cooperation/reactor/dispatcher.rb
+++ b/lib/process_host/cooperation/reactor/dispatcher.rb
@@ -1,0 +1,80 @@
+module ProcessHost
+  class Cooperation
+    class Reactor
+      class Dispatcher
+        attr_reader :reads
+        attr_reader :writes
+
+        dependency :logger, Telemetry::Logger
+
+        def initialize
+          @reads = []
+          @writes = []
+        end
+
+        def self.build
+          instance = new
+          Telemetry::Logger.configure instance
+          instance
+        end
+
+        def self.configure(receiver)
+          instance = build
+          receiver.dispatcher = instance
+        end
+
+        # Cycle reads and writes so that all tasks get a slice
+        def cycle_deferrals
+          reads.push reads.shift if reads.any?
+          writes.push writes.shift if writes.any?
+        end
+
+        def next(&block)
+          ready_reads, ready_writes = select
+
+          ready_reads.each { |deferral| deferral.callback.() }
+          ready_writes.each { |deferral| deferral.callback.() }
+
+          cycle_deferrals
+        end
+
+        def pending_read(io)
+          reads.detect do |deferral|
+            deferral.io == io
+          end
+        end
+
+        def pending_write(io)
+          writes.detect do |deferral|
+            deferral.io == io
+          end
+        end
+
+        def select
+          read_ios = reads.map &:io
+          write_ios = writes.map &:io
+
+          ready_reads, ready_writes, * = IO.select read_ios, write_ios, [], 1
+
+          read_deferrals = Array(ready_reads).map &method(:pending_read)
+          write_deferrals = Array(ready_writes).map &method(:pending_write)
+
+          return read_deferrals, write_deferrals
+        end
+
+        def wait_readable(io, &callback)
+          readable, * = IO.select [io], [], [], 0
+          logger.debug "Deferring read (Fileno: #{io.fileno})"
+          deferral = Deferral.new io, callback
+          reads << deferral unless pending_read io
+        end
+
+        def wait_writable(io, &callback)
+          logger.debug "Deferring write (Fileno: #{io.fileno})"
+          deferral = Deferral.new io, callback
+          writes << deferral unless pending_write io
+        end
+      end
+    end
+  end
+end

--- a/lib/process_host/process_host.rb
+++ b/lib/process_host/process_host.rb
@@ -15,7 +15,7 @@ module ProcessHost
       raise InvalidProcess.new self
     end
 
-    def change_connection_policy(*)
+    def change_connection_scheduler(*)
       raise InvalidProcess.new self
     end
   end
@@ -29,7 +29,7 @@ module ProcessHost
 
     def to_s
       <<-ERROR.chomp
-Process #{process.inspect} must implement a #start and a #change_connection_policy method
+Process #{process.inspect} must implement a #start and a #change_connection_scheduler method
       ERROR
     end
   end

--- a/process_host.gemspec
+++ b/process_host.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'telemetry-logger'
   s.add_runtime_dependency 'connection'
-  s.add_runtime_dependency 'http-protocol'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-spec-context'

--- a/process_host.gemspec
+++ b/process_host.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "process_host"
-  s.version     = "0.1.2"
+  s.version     = "0.2.0"
   s.summary     = "Run multiple logical processes inside a single physical process."
   s.description = "Turns your ruby program into a long running process that your init system can manage."
 

--- a/test/spec.rb
+++ b/test/spec.rb
@@ -4,4 +4,4 @@ Runner.('spec/**/*.rb') do |exclude|
   exclude =~ /(_init.rb|\.scratch.rb|\.skip\.rb)\z/
 end
 
-Minitest.run
+Minitest.run ARGV or exit 1

--- a/test/spec/cooperation/exception_handling.rb
+++ b/test/spec/cooperation/exception_handling.rb
@@ -1,9 +1,9 @@
-require_relative "./cooperation_tests_init"
+require_relative './cooperation_tests_init'
 
 module RaisesError
   class Error < StandardError
     def to_s
-      "raises-error"
+      'raises-error'
     end
   end
 
@@ -11,11 +11,11 @@ module RaisesError
     raise Error
   end
 
-  def self.change_connection_policy(*)
+  def self.change_connection_scheduler(*)
   end
 end
 
-describe "Error handling" do
+describe 'Error handling' do
   errors = {}
 
   cooperation = ProcessHost::Cooperation.build
@@ -29,7 +29,7 @@ describe "Error handling" do
   rescue RaisesError::Error
   end
 
-  specify "Errors" do
-    assert errors == { "RaisesError" => "raises-error" }
+  specify 'Errors' do
+    assert errors == { 'RaisesError' => 'raises-error' }
   end
 end

--- a/test/spec/cooperation/exception_handling.rb
+++ b/test/spec/cooperation/exception_handling.rb
@@ -19,9 +19,9 @@ describe 'Error handling' do
   errors = {}
 
   cooperation = ProcessHost::Cooperation.build
-  cooperation.register RaisesError
+  cooperation.register RaisesError, 'RaisesError'
   cooperation.exception_notifier = -> process, error do
-    errors[process.to_s] = error.to_s
+    errors[process] = error.to_s
   end
 
   begin
@@ -30,6 +30,7 @@ describe 'Error handling' do
   end
 
   specify 'Errors' do
+    __logger.data errors
     assert errors == { 'RaisesError' => 'raises-error' }
   end
 end


### PR DESCRIPTION
The `change_connection_policy` method has been replaced with `change_scheduler_policy`. We should consider supporting both for the time being, so we don't have to schedule a coordinated release. Although, that may be desirable.
